### PR TITLE
Updating version to 1.1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
-
+!/abs.yaml
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.
 !/**/

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-openai" %}
-{% set version = "0.3.16" %}
+{% set version = "1.1.7" %}
 
 package:
   name: langchain-openai
@@ -7,37 +7,40 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/langchain-openai/langchain_openai-{{ version }}.tar.gz
-  sha256: 4e423e39d072f1432adc9430f2905fe635cc019f01ad1bdffa5ed8d0dda32149
+  sha256: f5ec31961ed24777548b63a5fe313548bc6e0eb9730d6552b8c6418765254c81
 
 build:
-  number: 1
-  skip: True  # [py<39]
+  number: 0
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
     - python
     - pip
-    - pdm-backend
+    - hatchling
   run:
     - python
-    - langchain-core >=0.3.58,<1
-    - openai >=1.68.2,<2.0.0
-    - tiktoken >=0.7,<1
+    - langchain-core >=1.2.6,<2.0.0
+    - openai >=1.109.1,<3.0.0
+    - tiktoken >=0.7,<1.0.0
 
 test:
   source_files:
-    - tests
+    - tests/unit_tests
   requires:
     # Commented dependencies are ones that are specified by upstream but missing on our channels
     - pip
-    - pytest >=7.3.0,<8
+    - pytest >=7.3.0,<8 # [py<314]
+    - pytest >=8.4.2,<9 # [py>=314]
     - freezegun >=1.2.2,<2
     - pytest-mock >=3.10.0,<4
     # - syrupy >=4.0.2,<5
     # - pytest-watcher >=0.3.4,<1
-    - pytest-asyncio >=0.21.1,<1
-    - pytest-cov >=4.1.0,<5
+    - pytest-asyncio >=0.21.1,<1 # [py<314]
+    - pytest-asyncio >=1,<2 # [py>=314]
+    - pytest-cov >=4.1.0,<5 # [py<314]
+    - pytest-cov >=5 # [py>=314]
     # - pytest-retry >=1.7.0,<1.8.0
     - pytest-socket >=0.6.0,<1
     - pytest-xdist >=3.6.1,<4
@@ -51,6 +54,9 @@ test:
     {% set pytest_flags = pytest_flags + " --ignore=tests/unit_tests/chat_models" %}
     {% set pytest_flags = pytest_flags + " --ignore=tests/unit_tests/embeddings/test_base_standard.py" %}
     {% set pytest_flags = pytest_flags + " --ignore=tests/unit_tests/embeddings/test_azure_standard.py" %}
+    {% set pytest_flags = pytest_flags + " --ignore=tests/unit_tests/middleware/test_openai_moderation_middleware.py" %}
+    {% set pytest_flags = pytest_flags + " --deselect=tests/unit_tests/test_tools.py::test_async_custom_tool" %}
+    {% set pytest_flags = pytest_flags + " --deselect=tests/unit_tests/embeddings/test_base.py::test_embed_with_kwargs_async" %}
     - pytest -vv tests/unit_tests {{ pytest_flags }}
   imports:
     - langchain_openai

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,12 +62,12 @@ test:
     - langchain_openai
 
 about:
-  home: https://github.com/langchain-ai/langchain/tree/master/libs/partners/openai
+  home: https://docs.langchain.com/oss/python/integrations/providers/openai
   license: MIT
   license_file: LICENSE
   license_family: MIT
   dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/partners/openai
-  doc_url: https://python.langchain.com/docs/integrations/providers/openai/
+  doc_url: https://reference.langchain.com/python/integrations/langchain_openai
   summary: LangChain integrations for OpenAI through their openai SDK
   description: This package contains the LangChain integrations for OpenAI through their openai SDK.
 


### PR DESCRIPTION
langchain-openai 1.1.7

**Destination channel:** defaults

### Links

- [PKG-12245](https://anaconda.atlassian.net/browse/PKG-12245) 
- [Upstream repository](https://github.com/langchain-ai/langchain)
### Explanation of changes:

- New version number
- updating dependency


[PKG-12245]: https://anaconda.atlassian.net/browse/PKG-12245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ